### PR TITLE
Fixed some problems with some Paths.

### DIFF
--- a/PyFlow/Core/Widget.py
+++ b/PyFlow/Core/Widget.py
@@ -783,6 +783,10 @@ class GraphWidget(QGraphicsView, Graph):
             if not path.isfile(self._current_file_name):
                 name_filter = "Graph files (*.pyGraph)"
                 pth = QFileDialog.getSaveFileName(filter=name_filter)
+                
+                if type(pth) in [tuple,list]:
+                    pth = pth[0]
+                
                 if not pth == '':
                     self._current_file_name = pth
                 else:

--- a/PyFlow/Nodes/pythonNode.py
+++ b/PyFlow/Nodes/pythonNode.py
@@ -142,7 +142,10 @@ class pythonNode(Node, NodeBase):
         name_filter = "Node Files (*.py)"
         pth = QFileDialog.getSaveFileName(filter=name_filter)
         if not pth == '':
-            file_path = pth
+            if type(pth) in [tuple,list]:
+                file_path = pth[0]
+            else:
+                file_path = pth
             path,name = os.path.split(file_path)
             name,ext = os.path.splitext(name)
             if name in existing_nodes:


### PR DESCRIPTION
The path returned by `QFileDialog.getSaveFileName(filter=name_filter)` some times is a tuple or a list and some times a string, to fix this problem we have to check if we are getting a tuple or a string and use the first value of the tuple if it is one in order to get the right value for the Path of the file.