### PR TITLE
Added Aenum to the pip install command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Watch [video](https://youtu.be/chnRrr1Qfj8)
 2. Install [conda](https://conda.io/miniconda.html) with pyside2 and python 2.7 environment. [Instruction](https://fredrikaverpil.github.io/2017/08/28/pyside2-easy-install/) here
 3. Go to **Scripts/** folder and install dependencies
 	```bash
-	pip install Qt.py pyrr enum34
+	pip install Qt.py pyrr enum34 aenum
 	```
 4. Execute **starter.bat**
 


### PR DESCRIPTION
Aenum is not listed on the pip install command but its needed to run PyFlow, people are getting errors about it.