### PR TITLE
Trivial source comment typo fixes

### DIFF
--- a/PyFlow/Core/FunctionLibrary.py
+++ b/PyFlow/Core/FunctionLibrary.py
@@ -20,7 +20,7 @@ empty = {}
 # @param[in] func decorated function
 # @param[in] returns it can be tuple with [data type identifier](@ref PyFlow.Core.Common.DataTypes) + default value, or None
 # @param[in] meta dictionary with category path, keywords and any additional info
-# @param[in] nodeType determines wheter it is a Pure node or Callable. If Callable - input and output execution pins will be created
+# @param[in] nodeType determines whether it is a Pure node or Callable. If Callable - input and output execution pins will be created
 # @sa [NodeTypes](@ref PyFlow.Core.Common.NodeTypes) FunctionLibraries
 def IMPLEMENT_NODE(func=None, returns=empty, meta={'Category': 'Default', 'Keywords': []}, nodeType=NodeTypes.Pure):
     def wrapper(func):

--- a/PyFlow/Core/Interfaces.py
+++ b/PyFlow/Core/Interfaces.py
@@ -178,7 +178,7 @@ class IPin(IItemBase):
         Defines how data is processed.
 
         Returns:
-            procesed data
+            processed data
         '''
 
         return data

--- a/PyFlow/Tests/Test_General.py
+++ b/PyFlow/Tests/Test_General.py
@@ -104,7 +104,7 @@ class TestGeneral(unittest.TestCase):
         # n3.b is connected with n1.out
         # we expect n3.b breaks all connections before connecting with n2.out
         c2 = connectPins(n2Out, n3b)
-        # check connections successfull
+        # check connections successful
         self.assertEqual(c2, True)
         # check n2.out affects on n3.b
         self.assertEqual(n3b in n2Out.affects, True, "incorrect connection")

--- a/PyFlow/UI/CompileUiQt.py
+++ b/PyFlow/UI/CompileUiQt.py
@@ -10,7 +10,7 @@ INTERPRETER_PATH = 'python.exe'
 def ui_to_py(ui_file):
     '''
     << ui_to_py(ui_file, py_file_name) >>
-    convert *.ui to *.py to te same folder
+    convert *.ui to *.py to the same folder
     '''
     if not os.path.isfile(ui_file):
         msg = 'no such file'

--- a/PyFlow/UI/Views/CodeEditor.py
+++ b/PyFlow/UI/Views/CodeEditor.py
@@ -30,7 +30,7 @@ them as you would like them to be located on the node.
 When save button is pressed, function with code you wrote will be generated and used as node's compute method.
 
     Examples:
-        # you can acess pins in two ways
+        # you can access pins in two ways
         # like so
         >>> self.pinName.getData()
         >>> self.pinName.setData(value)

--- a/PyFlow/UI/Widgets/InputWidgets.py
+++ b/PyFlow/UI/Widgets/InputWidgets.py
@@ -40,7 +40,7 @@ class InputWidgetRaw(QWidget, IInputWidget):
     def __init__(self, parent=None, dataSetCallback=None, defaultValue=None, **kwds):
         super(InputWidgetRaw, self).__init__(parent=parent, **kwds)
         self._defaultValue = defaultValue
-        # fuction with signature void(object)
+        # function with signature void(object)
         # this will set data to pin
         self.dataSetCallback = dataSetCallback
         self._widget = None


### PR DESCRIPTION
Found via `codespell -q 3 -L conection,ege,lod,minimun -S /PyFlow/Packages`