### PR TITLE
Fix for OS X and unix command line to launch external editor.

### DIFF
--- a/PyFlow/Packages/PyFlowBase/UI/UIPythonNode.py
+++ b/PyFlow/Packages/PyFlowBase/UI/UIPythonNode.py
@@ -18,7 +18,6 @@ import subprocess
 import os
 import uuid
 import logging
-import shlex
 
 from Qt.QtWidgets import QAction
 from Qt.QtWidgets import QFileDialog
@@ -218,5 +217,5 @@ class UIPythonNode(UINodeBase):
             pass
 
         result = UIPythonNode.watcher.fileChanged.connect(self.onFileChanged)
-        self.currentEditorProcess = subprocess.Popen(shlex.split(editCmd))
+        self.currentEditorProcess = subprocess.Popen(editCmd, shell=True)
         self.fileHandle = open(self._filePath, 'r')

--- a/PyFlow/Packages/PyFlowBase/UI/UIPythonNode.py
+++ b/PyFlow/Packages/PyFlowBase/UI/UIPythonNode.py
@@ -18,6 +18,7 @@ import subprocess
 import os
 import uuid
 import logging
+import shlex
 
 from Qt.QtWidgets import QAction
 from Qt.QtWidgets import QFileDialog
@@ -217,5 +218,5 @@ class UIPythonNode(UINodeBase):
             pass
 
         result = UIPythonNode.watcher.fileChanged.connect(self.onFileChanged)
-        self.currentEditorProcess = subprocess.Popen(editCmd)
+        self.currentEditorProcess = subprocess.Popen(shlex.split(editCmd))
         self.fileHandle = open(self._filePath, 'r')


### PR DESCRIPTION
Quotes around file name in OS X comman line doesn't work.
Popen works better with list of parameters.
Found solution here.
https://docs.python.org/3.4/library/subprocess.html  
17.5.1.2. Popen Constructor  

**This PR is not tested with Windows.**