### PR TITLE
Undefined name: long was removed in Python 3

### DIFF
--- a/integrations/maya/maya_launcher.py
+++ b/integrations/maya/maya_launcher.py
@@ -4,6 +4,11 @@ from shiboken2 import wrapInstance
 from PyFlow.App import PyFlow
 from PySide2.QtWidgets import QWidget
 
+try:
+    long  # Python 2
+except NameError:
+    long = int  # Python 3
+
 ptvsd.enable_attach(address=('0.0.0.0', 3000), redirect_output=True)
 
 mayaMainWindowPtr = omui.MQtUtil.mainWindow()


### PR DESCRIPTION
__long__ was removed in Python 3 because all __int__ are of infinite precision.