### PR TITLE
Fix: 'QPainterPath' object is not subscriptable

### DIFF
--- a/PyFlow/UI/Canvas/UIConnection.py
+++ b/PyFlow/UI/Canvas/UIConnection.py
@@ -522,7 +522,7 @@ class UIConnection(QGraphicsPathItem):
             self.mPath = ConnectionPainter.Cubic(p1, p2, 150, lod)
             self.linPath = None
         elif editableStyleSheet().ConnectionMode[0] == ConnectionTypes.Linear:
-            self.mPath = ConnectionPainter.Linear(p1, p2, offset, roundness, lod)
+            self.mPath, _ = ConnectionPainter.Linear(p1, p2, offset, roundness, lod)
             self.linPath = None
         if self.snapVToSecond and self.offsetting == 0:
             self.vOffset = p2.y() - p1.y()


### PR DESCRIPTION
Fixing this error when using Linear connection
TypeError: 'PySide2.QtGui.QPainterPath' object is not subscriptable