### PR TITLE
Clean up instances at program end

### DIFF
--- a/PyFlow/Core/Common.py
+++ b/PyFlow/Core/Common.py
@@ -726,6 +726,8 @@ class SingletonDecorator:
         self.allInstances.append(self)
 
     def destroy(self):
+        if ('destroy' in dir(self.instance)):
+            self.instance.destroy()
         del self.instance
         self.instance = None
 


### PR DESCRIPTION
When the program is closed, the instances can be cleaned up using the destroy method.