### PR TITLE
Allow selecting non-existing files in FileDialog

### DIFF
--- a/PyFlow/UI/Widgets/FileDialog.py
+++ b/PyFlow/UI/Widgets/FileDialog.py
@@ -15,7 +15,7 @@ class FileDialog(QFileDialog):
                     but.clicked.connect(self.chooseClicked)
 
         elif mode == "file":
-            self.setFileMode(QFileDialog.ExistingFile)
+            self.setFileMode(QFileDialog.AnyFile)
 
         elif mode == "directory":
             self.setFileMode(QFileDialog.DirectoryOnly)


### PR DESCRIPTION
Currently, it is only possible to select an existing file when using the FilePathWidget. Sometimes it is necessary to define a filename that does not exist, such as when generating any output file. This change allows for the selection of a filename that does not exist.