### PR TITLE
Unfold nodebox items by default

### DIFF
--- a/PyFlow/UI/Views/NodeBox.py
+++ b/PyFlow/UI/Views/NodeBox.py
@@ -544,7 +544,7 @@ class NodesBox(QFrame):
             item = self.treeWidget.topLevelItem(i)
             if item.text(0) in self.treeWidget.categoryPaths:
                 index = self.treeWidget.indexFromItem(item)
-                self.treeWidget.setExpanded(index, True)
+                self.treeWidget.expandRecursively(index)
 
     def leTextChanged(self):
         if self.lineEdit.text() == "":


### PR DESCRIPTION
Before when searching for nodes the categories wouldn't unfold by default. This should fix that.

I believe this addresses issue #125