### PR TITLE
bugfix: codecs.open()

### DIFF
--- a/PyFlow/Packages/PyFlowBase/FunctionLibraries/IOLib.py
+++ b/PyFlow/Packages/PyFlowBase/FunctionLibraries/IOLib.py
@@ -56,7 +56,7 @@ class IOLib(FunctionLibraryBase):
                      error_msg=(REF, ('StringPin', ""))):
         err_msg = ""
         try:
-             with codecs.open(file, encoding) as f:
+             with codecs.open(file, encoding=encoding) as f:
                 all_lines = list(f.readlines())
         except Exception as e:
             err_msg = str(e)


### PR DESCRIPTION
codecs.open(filename, mode='r', encoding=None, errors='strict', buffering=-1)