### PR TITLE
Minor function lib bugfixes

### DIFF
--- a/PyFlow/Packages/PyFlowBase/FunctionLibraries/PathLib.py
+++ b/PyFlow/Packages/PyFlowBase/FunctionLibraries/PathLib.py
@@ -280,9 +280,9 @@ class PathLib(FunctionLibraryBase):
         base=("StringPin", "", {PinSpecifiers.INPUT_WIDGET_VARIANT: "PathWidget"}),
         paths=("StringPin", []),
     ):
-        """Join one or more path components intelligently. The return value is the concatenation of path and any members of *paths with exactly one directory separator (os.sep) following each non-empty part except the last, meaning that the result will only end in a separator if the last part is empty. If a component is an absolute path, all previous components are thrown away and joining continues from the absolute path component.
-        On Windows, the drive letter is not reset when an absolute path component (e.g., r'\foo') is encountered. If a component contains a drive letter, all previous components are thrown away and the drive letter is reset. Note that since there is a current directory for each drive, os.path.join("c:", "foo") represents a path relative to the current directory on drive C: (c:foo), not c:\foo."""
-        return osPath.join(base, paths)
+        """Join one or more path components intelligently. The return value is the concatenation of path and any members of \\*paths with exactly one directory separator (os.sep) following each non-empty part except the last, meaning that the result will only end in a separator if the last part is empty. If a component is an absolute path, all previous components are thrown away and joining continues from the absolute path component.
+        On Windows, the drive letter is not reset when an absolute path component (e.g., r'\\\\foo') is encountered. If a component contains a drive letter, all previous components are thrown away and the drive letter is reset. Note that since there is a current directory for each drive, os.path.join("c:", "foo") represents a path relative to the current directory on drive C: (c:foo), not c:\\\\foo."""
+        return osPath.join(base, *paths)
 
     @staticmethod
     @IMPLEMENT_NODE(
@@ -425,7 +425,7 @@ class PathLib(FunctionLibraryBase):
         unc=(REF, ("StringPin", "")),
         rest=(REF, ("StringPin", "")),
     ):
-        """Split the pathname path into a pair (unc, rest) so that unc is the UNC mount point (such as r'\\host\mount'), if present, and rest the rest of the path (such as r'\path\file.ext'). For paths containing drive letters, unc will always be the empty string."""
+        """Split the pathname path into a pair (unc, rest) so that unc is the UNC mount point (such as r'\\\\\\\\host\\\\mount'), if present, and rest the rest of the path (such as r'\\\\path\\\\file.ext'). For paths containing drive letters, unc will always be the empty string."""
         splited = osPath.splitdrive(path)
         if len(splited):
             unc(splited[0])

--- a/PyFlow/Packages/PyFlowBase/FunctionLibraries/StringLib.py
+++ b/PyFlow/Packages/PyFlowBase/FunctionLibraries/StringLib.py
@@ -80,13 +80,13 @@ class StringLib(FunctionLibraryBase):
         return str.split(s, sep)
     
     @staticmethod
-    @IMPLEMENT_NODE(returns=('StringPin', [], {PinSpecifiers.CONSTRAINT: '1', PinSpecifiers.ENABLED_OPTIONS: PinOptions.ArraySupported}), 
+    @IMPLEMENT_NODE(returns=('BoolPin', False, {PinSpecifiers.CONSTRAINT: '1'}), 
                     meta={NodeMeta.CATEGORY: 'String', NodeMeta.KEYWORDS: []})
-    def starstWith(s=('StringPin', ""), prefix=('StringPin', "", { PinSpecifiers.ENABLED_OPTIONS: PinOptions.ArraySupported|PinOptions.ChangeTypeOnConnection })):
+    def startsWith(s=('StringPin', ""), prefix=('StringPin', "", { PinSpecifiers.ENABLED_OPTIONS: PinOptions.ArraySupported|PinOptions.ChangeTypeOnConnection })):
         return s.startswith(prefix)
     
     @staticmethod
-    @IMPLEMENT_NODE(returns=('StringPin', [], {PinSpecifiers.CONSTRAINT: '1', PinSpecifiers.ENABLED_OPTIONS: PinOptions.ArraySupported}), 
+    @IMPLEMENT_NODE(returns=('BoolPin', False, {PinSpecifiers.CONSTRAINT: '1'}), 
                     meta={NodeMeta.CATEGORY: 'String', NodeMeta.KEYWORDS: []})
     def endsWith(s=('StringPin', ""), suffix=('StringPin', "", { PinSpecifiers.ENABLED_OPTIONS: PinOptions.ArraySupported|PinOptions.ChangeTypeOnConnection })):
         return s.endswith(suffix)

--- a/PyFlow/Packages/PyFlowBase/Nodes/sequence.py
+++ b/PyFlow/Packages/PyFlowBase/Nodes/sequence.py
@@ -66,5 +66,5 @@ class sequence(NodeBase):
         return "The Sequence node allows for a single execution pulse to trigger a series of events in order. The node may have any number of outputs, all of which get called as soon as the Sequence node receives an input. They will always get called in order, but without any delay. To a typical user, the outputs will likely appear to have been triggered simultaneously."
 
     def compute(self, *args, **kwargs):
-        for out in self.outputs.values():
+        for out in self.orderedOutputs.values():
             out.call(*args, **kwargs)


### PR DESCRIPTION
Hi,

Please consider the following bugfixes in this PR:
  + StringLib: starstWith typo + wrong return type, endsWith wrong return type
  + PathLib: escapes and osPath.join(base, *paths) (asterisk was missing)
  + sequence: run out pins in order
