### PR TITLE
Fix Python 3.14 asyncio event loop compatibility

### DIFF
--- a/PyFlow/App.py
+++ b/PyFlow/App.py
@@ -35,6 +35,7 @@ from PyFlow.Core.GraphManager import GraphManagerSingleton
 from PyFlow.Core.Common import currentProcessorTime
 from PyFlow.Core.Common import SingletonDecorator
 from PyFlow.Core.Common import validateGraphDataPackages
+from PyFlow.Core.AsyncLoop import close_event_loop, get_or_create_event_loop
 from PyFlow.UI.Canvas.UICommon import SessionDescriptor
 from PyFlow.UI.Widgets.BlueprintCanvas import BlueprintCanvasWidget
 from PyFlow.UI.Tool.Tool import ShelfTool, DockTool
@@ -486,7 +487,7 @@ class PyFlow(QMainWindow):
         self.tick_timer.timeout.disconnect()
 
     def mainLoop(self):
-        asyncio.get_event_loop().run_until_complete(self._tick_asyncio())
+        get_or_create_event_loop().run_until_complete(self._tick_asyncio())
         
         deltaTime = currentProcessorTime() - self._lastClock
         ds = deltaTime * 1000.0
@@ -634,6 +635,7 @@ class PyFlow(QMainWindow):
         if os.path.exists(self.currentTempDir):
             shutil.rmtree(self.currentTempDir)
 
+        close_event_loop()
         SingletonDecorator.destroyAll()
 
         PyFlow.appInstance = None

--- a/PyFlow/Core/AsyncLoop.py
+++ b/PyFlow/Core/AsyncLoop.py
@@ -1,0 +1,59 @@
+## Copyright 2015-2019 Ilgar Lunin, Pedro Cabrera
+
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+
+##     http://www.apache.org/licenses/LICENSE-2.0
+
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+
+import asyncio
+
+
+_PYFLOW_EVENT_LOOP = None
+
+
+def get_or_create_event_loop():
+    global _PYFLOW_EVENT_LOOP
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop is not None:
+        _PYFLOW_EVENT_LOOP = loop
+        return loop
+
+    if _PYFLOW_EVENT_LOOP is None or _PYFLOW_EVENT_LOOP.is_closed():
+        _PYFLOW_EVENT_LOOP = asyncio.new_event_loop()
+
+    asyncio.set_event_loop(_PYFLOW_EVENT_LOOP)
+    return _PYFLOW_EVENT_LOOP
+
+
+def close_event_loop():
+    global _PYFLOW_EVENT_LOOP
+
+    loop = _PYFLOW_EVENT_LOOP
+    _PYFLOW_EVENT_LOOP = None
+
+    if loop is None:
+        asyncio.set_event_loop(None)
+        return
+
+    if not loop.is_closed():
+        pending = [task for task in asyncio.all_tasks(loop) if not task.done()]
+        for task in pending:
+            task.cancel()
+        if pending:
+            loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+        loop.close()
+
+    asyncio.set_event_loop(None)

--- a/PyFlow/Packages/PyFlowBase/Nodes/subProcess.py
+++ b/PyFlow/Packages/PyFlowBase/Nodes/subProcess.py
@@ -16,6 +16,7 @@
 import asyncio
 import time
 import uuid
+from PyFlow.Core.AsyncLoop import get_or_create_event_loop
 from PyFlow.Core import NodeBase, PinBase
 from PyFlow.Core.Common import *
 from PyFlow.Core.NodeBase import NodePinsSuggestionsHelper
@@ -133,7 +134,10 @@ class subProcess(NodeBase):
             self.proc_task_args = args
             self.proc_task_kwargs = kwargs
             self.is_running.setData(True)
-            self.proc_task = asyncio.get_event_loop().create_task(self._run_cmd(self.proc_task_uuid, cmd, self.cwd.getData()))
+            loop = get_or_create_event_loop()
+            self.proc_task = loop.create_task(
+                self._run_cmd(self.proc_task_uuid, cmd, self.cwd.getData())
+            )
         
     async def _run_cmd(self, _uuid, cmd, cwd):
         if None != self.proc and None == self.proc.returncode:

--- a/PyFlow/Tests/Test_AsyncioCompatibility.py
+++ b/PyFlow/Tests/Test_AsyncioCompatibility.py
@@ -1,0 +1,84 @@
+## Copyright 2015-2019 Ilgar Lunin, Pedro Cabrera
+
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+
+##     http://www.apache.org/licenses/LICENSE-2.0
+
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+
+import asyncio
+import unittest
+
+from PyFlow.App import PyFlow
+from PyFlow.Core.Common import currentProcessorTime
+from PyFlow.Packages.PyFlowBase.Nodes.subProcess import subProcess
+from PyFlow.Tests.TestsBase import INITIALIZE
+
+
+class _TickRecorder(object):
+    def __init__(self):
+        self.deltas = []
+
+    def get(self):
+        return self
+
+    def Tick(self, delta):
+        self.deltas.append(delta)
+
+
+class _DummyPyFlow(object):
+    def __init__(self):
+        self._lastClock = currentProcessorTime()
+        self.fps = 0
+        self.graphManager = _TickRecorder()
+        self.canvasWidget = _TickRecorder()
+
+    async def _tick_asyncio(self):
+        await asyncio.sleep(0)
+
+
+class TestAsyncioCompatibility(unittest.TestCase):
+    def setUp(self):
+        self._loops = []
+        asyncio.set_event_loop(None)
+        INITIALIZE()
+
+    def tearDown(self):
+        for loop in self._loops:
+            if loop is None or loop.is_closed():
+                continue
+            pending = [task for task in asyncio.all_tasks(loop) if not task.done()]
+            for task in pending:
+                task.cancel()
+            if pending:
+                loop.run_until_complete(
+                    asyncio.gather(*pending, return_exceptions=True)
+                )
+            loop.close()
+
+        asyncio.set_event_loop(None)
+
+    def test_main_loop_runs_without_implicit_default_event_loop(self):
+        dummy = _DummyPyFlow()
+
+        PyFlow.mainLoop(dummy)
+        self._loops.append(asyncio.get_event_loop())
+
+        self.assertEqual(len(dummy.graphManager.deltas), 1)
+        self.assertEqual(len(dummy.canvasWidget.deltas), 1)
+
+    def test_subprocess_compute_creates_task_without_implicit_default_event_loop(self):
+        node = subProcess("cmd")
+        node.cmd.setData("echo")
+
+        node.compute()
+
+        self.assertIsNotNone(node.proc_task)
+        self._loops.append(node.proc_task.get_loop())


### PR DESCRIPTION
### Summary

Fix Python 3.14 support in the standalone editor after [`asyncio.get_event_loop()`](https://docs.python.org/3.14/library/asyncio-eventloop.html#asyncio.get_event_loop) changed behavior in Python 3.14.

This updates the editor tick path and `subProcess` node task creation, and adds a regression test for both cases.

### Problem

According to the [Python 3.14 event loop documentation](https://docs.python.org/3.14/library/asyncio-eventloop.html#asyncio.get_event_loop), `asyncio.get_event_loop()` now raises `RuntimeError` if there is no current event loop.

PyFlow still relied on the old behavior in:

- `PyFlow/App.py`
- `PyFlow/Packages/PyFlowBase/Nodes/subProcess.py`

That caused standalone startup to fail with:

`RuntimeError: There is no current event loop in thread 'MainThread'`

<img width="1251" height="441" alt="image" src="https://github.com/user-attachments/assets/45c4d57c-b321-4d63-a32c-f397a99e714b" />

### Fix

- Add a small shared event loop helper in `PyFlow/Core/AsyncLoop.py`
- Create and reuse that loop when PyFlow is running without a current default event loop
- Use the shared loop in `PyFlow/App.py` so the standalone editor tick no longer depends on `asyncio.get_event_loop()`
- Use the same shared loop in `PyFlow/Packages/PyFlowBase/Nodes/subProcess.py` when creating async tasks
- Clean up the shared loop on app shutdown
- Add regression coverage for both failure points so the editor tick path and `subProcess` path are both checked

### Compatibility

Verified on Python 3.9 through 3.14.

Existing tests pass, and the standalone editor no longer hits the repeated event loop error on Python 3.14.